### PR TITLE
Fake authentication #20

### DIFF
--- a/thousands/__init__.py
+++ b/thousands/__init__.py
@@ -25,8 +25,6 @@ if 'OPENSHIFT_DATA_DIR' in os.environ:
     app.config.from_pyfile(os.path.join(os.environ['OPENSHIFT_DATA_DIR'],
                            'thousands.conf'))
 
-if app.config['TESTING']:
-    print "!!! TESTING MODE"
 
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 pool = psycopg2.pool.SimpleConnectionPool(1, 10, app.config['PG_DSN'])

--- a/thousands/__init__.py
+++ b/thousands/__init__.py
@@ -25,6 +25,9 @@ if 'OPENSHIFT_DATA_DIR' in os.environ:
     app.config.from_pyfile(os.path.join(os.environ['OPENSHIFT_DATA_DIR'],
                            'thousands.conf'))
 
+if app.config['TESTING']:
+    print "!!! TESTING MODE"
+
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 pool = psycopg2.pool.SimpleConnectionPool(1, 10, app.config['PG_DSN'])
 

--- a/thousands/auth.py
+++ b/thousands/auth.py
@@ -60,13 +60,13 @@ def vk_login():
     return oauth_login(request, vk_flow('state'), vk_get_user)
 
 
-@app.route('/login/as/<user_id>')
+@app.route('/login/as/<int:user_id>')
 def login_as(user_id):
-    if app.config['TESTING']:
+    if app.config['DEBUG']:
         user = g.users_dao.get_by_id(unicode(user_id))
         if user is None:
             abort(404)
-        login_user(user, False, True)
+        login_user(user)
         return redirect('/user/' + str(user.id))
     else:
         abort(404)

--- a/thousands/auth.py
+++ b/thousands/auth.py
@@ -60,6 +60,18 @@ def vk_login():
     return oauth_login(request, vk_flow('state'), vk_get_user)
 
 
+@app.route('/login/as/<user_id>')
+def login_as(user_id):
+    if app.config['TESTING']:
+        user = g.users_dao.get_by_id(unicode(user_id))
+        if user is None:
+            abort(404)
+        login_user(user, False, True)
+        return redirect('/user/' + str(user.id))
+    else:
+        abort(404)
+
+
 def oauth_login(req, flow, get_user):
     if 'error' in request.args.keys():
         return make_response(req.args.get('error_description'))


### PR DESCRIPTION
A very simple solution: 

Provides /login/as/<user_id> endpoint. Redirects to /user/<user_id>, otherwise 404.
Available only in "testing mode", otherwise 404.
Turning on testing mode: 
`TESTING=True`
in `application.conf`
